### PR TITLE
Documento CT: removed field ufficio_responsabile already defined in design.plone.contenttypes

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # python cache
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -14,7 +14,7 @@ jobs:
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # python cache
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -14,7 +14,7 @@ jobs:
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pyroma.yml
+++ b/.github/workflows/pyroma.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # python cache
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/pyroma.yml
+++ b/.github/workflows/pyroma.yml
@@ -14,7 +14,7 @@ jobs:
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/zpretty.yml
+++ b/.github/workflows/zpretty.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       # python cache
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/zpretty.yml
+++ b/.github/workflows/zpretty.yml
@@ -14,7 +14,7 @@ jobs:
 
       # python setup
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Documento CT: removed field ufficio_responsabile already defined in design.plone.contenttypes.
+  [daniele]
 
 1.0.5 (2025-07-16)
 ------------------

--- a/src/design/plone/ctgeneric/behaviors/documento.py
+++ b/src/design/plone/ctgeneric/behaviors/documento.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 from design.plone.ctgeneric import _
-from plone.app.z3cform.widget import RelatedItemsFieldWidget
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.interfaces import IDexterityContent
 from plone.supermodel import model
-from z3c.relationfield.schema import RelationChoice
-from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import adapter
 from zope.interface import implementer
@@ -15,22 +12,6 @@ from zope.interface import provider
 
 @provider(IFormFieldProvider)
 class IDocumentoV2(model.Schema):
-    ufficio_responsabile = RelationList(
-        title=_(
-            "ufficio_responsabile_documento_label",
-            default="Ufficio responsabile del documento",
-        ),
-        description=_(
-            "ufficio_responsabile_documento_help",
-            default="Seleziona l'ufficio responsabile di questo documento.",
-        ),
-        required=True,
-        default=[],
-        value_type=RelationChoice(
-            title=_("Ufficio responsabile"),
-            vocabulary="plone.app.vocabularies.Catalog",
-        ),
-    )
     tipologia_documento = schema.Choice(
         title=_("tipologia_documento_label", default="Tipologia del documento"),
         description=_(
@@ -41,29 +22,8 @@ class IDocumentoV2(model.Schema):
         vocabulary="design.plone.vocabularies.tipologie_documento",
     )
 
-    # custom widgets
-    form.widget(
-        "ufficio_responsabile",
-        RelatedItemsFieldWidget,
-        vocabulary="plone.app.vocabularies.Catalog",
-        pattern_options={
-            "maximumSelectionSize": 1,
-            "selectableTypes": ["UnitaOrganizzativa"],
-        },
-    )
-
     # custom order
     form.order_after(tipologia_documento="identificativo")
-    form.order_before(ufficio_responsabile="licenza_distribuzione")
-
-    #  custom fieldsets
-    model.fieldset(
-        "descrizione",
-        label=_("descrizione_label", default="Descrizione"),
-        fields=[
-            "ufficio_responsabile",
-        ],
-    )
 
 
 @implementer(IDocumentoV2)

--- a/src/design/plone/ctgeneric/configure.zcml
+++ b/src/design/plone/ctgeneric/configure.zcml
@@ -20,7 +20,7 @@
   <include package=".browser" />
   <include package=".restapi" />
   <include package=".upgrades" />
-  
+
   <include package=".vocabularies" />
 
   <include file="monkey.zcml" />


### PR DESCRIPTION
For ct Documento the field "ufficio_responsabile" is already present in design.plone.contenttypes:

https://github.com/RedTurtle/design.plone.contenttypes/blob/2dad466c3556525f93082027f28a3d2bc94aacb8/src/design/plone/contenttypes/interfaces/documento.py#L68

This led to the issue of failing when trying to resolve the related office UID.